### PR TITLE
feat: Setup C project structure and Makefile for JPEG parser

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,35 @@
+# Compiler
+CC = gcc
+
+# Compiler flags
+CFLAGS = -Wall -g
+
+# Source files
+SRCS = jpeg_parser_phase1_marker_parsing.c \
+       jpeg_parser_phase2_huffman_decoding.c \
+       jpeg_parser_phase3_dct_reconstruction.c \
+       jpeg_parser_phase4_dct_encoding_and_writing.c
+
+# Object files - corresponding to source files
+OBJS = $(SRCS:.c=.o)
+
+# Target executable name
+TARGET = jpeg_parser
+
+# Default rule: build the target executable
+all: $(TARGET)
+
+# Rule to link object files into the target executable
+$(TARGET): $(OBJS)
+	$(CC) $(CFLAGS) -o $(TARGET) $(OBJS)
+
+# Rule to compile .c source files into .o object files
+%.o: %.c
+	$(CC) $(CFLAGS) -c $< -o $@
+
+# Clean rule: remove object files and the target executable
+clean:
+	rm -f $(OBJS) $(TARGET)
+
+# Phony targets
+.PHONY: all clean

--- a/jpeg_parser_phase1_marker_parsing.c
+++ b/jpeg_parser_phase1_marker_parsing.c
@@ -1,0 +1,16 @@
+#include <stdio.h>
+
+// Forward declarations for functions from other phases (if they were to be called from main)
+// int phase2_huffman_decode();
+// int phase3_dct_reconstruction();
+// int phase4_dct_encode_and_write();
+
+int main(int argc, char *argv[]) {
+    printf("JPEG Parser Phase 1: Marker Parsing - Initializing\n");
+    // Future calls to other phases:
+    // phase2_huffman_decode();
+    // phase3_dct_reconstruction();
+    // phase4_dct_encode_and_write();
+    printf("JPEG Parser Execution Complete (Placeholder)\n");
+    return 0;
+}

--- a/jpeg_parser_phase2_huffman_decoding.c
+++ b/jpeg_parser_phase2_huffman_decoding.c
@@ -1,0 +1,6 @@
+#include <stdio.h>
+
+int phase2_huffman_decode() {
+    printf("JPEG Parser Phase 2: Huffman Decoding - Placeholder\n");
+    return 0;
+}

--- a/jpeg_parser_phase3_dct_reconstruction.c
+++ b/jpeg_parser_phase3_dct_reconstruction.c
@@ -1,0 +1,6 @@
+#include <stdio.h>
+
+int phase3_dct_reconstruction() {
+    printf("JPEG Parser Phase 3: DCT Reconstruction - Placeholder\n");
+    return 0;
+}

--- a/jpeg_parser_phase4_dct_encoding_and_writing.c
+++ b/jpeg_parser_phase4_dct_encoding_and_writing.c
@@ -1,0 +1,6 @@
+#include <stdio.h>
+
+int phase4_dct_encode_and_write() {
+    printf("JPEG Parser Phase 4: DCT Encoding & Writing - Placeholder\n");
+    return 0;
+}


### PR DESCRIPTION
Adds the initial C source files for a multi-phase JPEG parser:
- jpeg_parser_phase1_marker_parsing.c
- jpeg_parser_phase2_huffman_decoding.c
- jpeg_parser_phase3_dct_reconstruction.c
- jpeg_parser_phase4_dct_encoding_and_writing.c

Each file currently contains placeholder content.
`jpeg_parser_phase1_marker_parsing.c` includes the `main()` function.

A Makefile has been added to compile these C files into a single executable named `jpeg_parser`. The Makefile includes:
- Compilation rules for individual .c files to .o object files.
- Linking rule for object files into the `jpeg_parser` executable.
- A `clean` rule to remove build artifacts.

The build process has been tested: `make` successfully builds the executable, and `make clean` removes all generated files. The placeholder executable runs and prints expected output.